### PR TITLE
Fix undefined descriptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ const flattenScripts = (scripts, prefix) => {
       // format = name: { default: command }
       if (typeof shape.default === 'string') {
         script = shape.default
-        description = shape.description
+        description = shape.description || ''
 
         delete shape.default
         delete shape.description
@@ -44,7 +44,7 @@ const flattenScripts = (scripts, prefix) => {
       // format = name: { script: command }
       if (typeof shape.script === 'string') {
         script = shape.script
-        description = shape.description
+        description = shape.description || ''
 
         delete shape.script
         delete shape.description


### PR DESCRIPTION
Scripts defined with a `script` property and no description print
"undefined" as the description. This commit fixes that by defaulting to
an empty string.